### PR TITLE
Creation de la BDD a la premiere initialisation du volume docker #23

### DIFF
--- a/MySql/Dockerfile-mysql
+++ b/MySql/Dockerfile-mysql
@@ -6,3 +6,6 @@ ENV MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-alcatel}
 ENV MYSQL_DATABASE=${MYSQL_DATABASE:-PTT}
 ENV MYSQL_USER=${MYSQL_USER:-alcatel}
 ENV MYSQL_PASSWORD=${MYSQL_PASSWORD:-alcatel}
+
+# Add the content of the sql-scripts/ directory to your image
+COPY create.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
**Creation de la BDD a la premiere initialisation du volume docker**

[Creation de la BDD a la premiere initialisation du volume docker #23] -> {[ISSUE_URL](https://github.com/PTT-Alcatel/backend/issues/23)}

**REQUIRES**

docker installed

**HOW TO TEST**

launch the docker without volume and check if the DB and tables are created

**CHANGES**

Added automatic init of the DB and tables using mysql entry point